### PR TITLE
Extract weights into yaml file

### DIFF
--- a/de-news.yml
+++ b/de-news.yml
@@ -1,0 +1,109 @@
+feeds:
+    ZEIT:
+        url: http://newsfeed.zeit.de/index
+        weight: 2
+    SpOn:
+        url: http://www.spiegel.de/index.rss
+        weight: 1
+    FAZ:
+        url: http://www.faz.net/rss/aktuell/
+        weight: 2
+    SZ:
+        url: http://rss.sueddeutsche.de/rss/Topthemen
+        weight: 2
+    Heise:
+        url: https://www.heise.de/newsticker/heise-top-atom.xml
+    Taz:
+        url: https://www.taz.de/!p4608;rss/
+        weight: -1
+    Focus:
+        url: http://rss.focus.de/
+    RT:
+        url: https://deutsch.rt.com/feeds/news/
+        weight: -2
+    TP:
+        url: https://www.heise.de/tp/news-atom.xml
+    HB:
+        url: http://www.handelsblatt.com/contentexport/feed/top-themen/
+        weight: 2
+    Compact:
+        url: https://www.compact-online.de/feed/
+        weight: -1
+    Correctiv:
+        url: https://correctiv.org/artikel/feeds/
+        weight: 3
+    NP:
+        url: https://netzpolitik.org/feed/
+        weight: 3
+    WU:
+        url: http://www.wahlumfrage.de/feed/
+    Carta:
+        url: https://feeds2.feedburner.com/carta-homepage-rss
+    BG:
+        url: https://feeds.feedburner.com/BerlinerGazette
+    Konj:
+        url: https://www.konjunktion.info/feed/
+        weight: 1
+    NZZ:
+        url: https://www.nzz.ch/international.rss
+        weight: 2
+    Freitag:
+        url: https://www.freitag.de/politik/@@RSS
+    Cicero:
+        url: http://cicero.de/rss.xml
+    WiWo:
+        url: http://www.wiwo.de/contentexport/feed/rss/schlagzeilen
+    NDS:
+        url: http://www.nachdenkseiten.de/?feed=atom
+weights:
+    tags:
+        -21: |
+            mode video bundesliga
+    keyword:
+        31: |
+            lidl aldi karlsruhe snowden
+        21: |
+            datenschutz netzpol amnesty ceta aleppo wikipedia eugh maidan nafta
+            nato uno krankenkasse vg-wort guantanamo fukushima bitcoin lammert
+        15: |
+            türkei putin hochschule urteil verdi apple google microsoft ibm iwf ezb
+            griechenland volksbegehren brexit airbus pentagon energiewende
+            windkraft lindner paragraf ditib nobelpreis armutsgrenze bundesbank
+            betriebsrat sparkurs bundesrat shinzō libyen mogherini indexfond orbán
+            panama-papers juncker netanyahu deutsche bank cyber-sicherheit yellen
+            windenergie maizière
+        9: |
+            nsu korruption siedlung steinmeier überwachung fracking android
+            bundesverwaltungsgericht bundesnetzagentur nationalpark syri winterkorn
+            piëch afghan erdoğan böhmermann wissenschaft endlager palästin nahost
+            tsipras rente unternehmenssteuer wilders krankenversicherung gesetz
+            klimaschutz jong-un trudeau BND drohnen peugeot opel orbán reisepass
+        7: |
+            afd usa trump minister bundestag wahl e-sport gentechnik merkel amazon
+            ebay paypal altmaier schäuble grexit ukraine agrar portugal sanktionen
+            samsung gysi lagarde vorratsspeicherung norovirus unilever
+            patientenakte bannon telefónica sudan unicef fintech salafis sufis
+            exportüberschuss telekom passwort bertelsmann kindergeld martin schulz
+        2: |
+            ddos berlin china bundespolizei russland japan lebensversicherung
+            präsident facebook anschlag europa deutsch immobilie whatsapp google
+            mcmaster leistungsschutzrecht bafin le\spen
+        -1: |
+            experte deepmind gauland bundeswehr delfin foto generation vorwürfe
+            unmut übersicht paukenschlag dax mord hollywood kampf oscar homöopath
+        -8: |
+            film wunder unisex tweet top\sten fantasi sexuell vögel fußball dfb
+            wahrheit manager salat voodoo berlinale portal theater schmutzig killer
+            kolumne ? skandal cowboy essay kritik münchen selfie mode terror
+            emotion viral nachruf sonneborn seehofer kokain marx junkie ikone
+            egoismus karikatur promi schock kreissäge valentinstag nackt könnte
+            bizarr spiel stur gefährlich hinweise meinung goethe schiller karneval
+            fasnacht fastnacht fasching pizza hölle damokles teambuilding doping
+            knigge
+        -19: |
+            kunst mies bayern horror brutal compact protz social wollmilch olympia
+            kommentar +++ schicksal billig troll hashtag betrunken lügendetektor
+            thriller mutig spektakulär krass checkliste ! zombie willkommen
+            elfmeter spiegel tv video sex ficken saufen schonungslos trumpismus
+            crazy kamikaze buchtipp verkackt playboy gastbeitrag shitstorm wäre
+            abgemagert einhorn

--- a/generate.py
+++ b/generate.py
@@ -2,13 +2,18 @@
 import sys
 import datetime
 import time
+import yaml
+import logging
+logging.basicConfig(level=logging.DEBUG)
 from functools import cmp_to_key
 from random import Random
-
-TGT = sys.argv[1]
-NOW = datetime.datetime.now()
-
 import feedparser
+
+DATA = sys.argv[1]
+NOW = datetime.datetime.now()
+with open(DATA, 'r') as handle:
+    conf = yaml.load(handle)
+
 
 def forbiddenMeta(meta):
     for w in ('satire', 'quiz'):
@@ -18,7 +23,7 @@ def forbiddenMeta(meta):
 
 def get_default(name, feedurl):
     feed = feedparser.parse(feedurl)
-    print("fetch "+feedurl)
+    logging.info("fetch "+feedurl)
     home_url = getattr(feed.feed, 'link', feedurl)
     name = '<a href="%s" class="meta">%s</a>' % (home_url, name)
     afternoon = (NOW.hour >= 12)
@@ -43,93 +48,55 @@ def get_default(name, feedurl):
         value = valueItem((e.link, title, name, dt, tags))
         yield e.link, title, name, dt, tags, value
 
+def boost_it(section):
+    for score_group in conf['weights'][section]:
+        words = conf['weights'][section][score_group].strip().split()
+        # Replace spaces
+        words = [x.replace('\s', ' ') for x in words]
+        yield (score_group, words)
+
 def valueItem(item):
     value = 0
     # Value title content
     title = item[1].lower()
-    for w in ('lidl', 'aldi', 'karlsruhe', 'snowden'):
-        if w in title:
-            value += 31
-    for w in ('datenschutz', 'netzpol', 'amnesty', 'ceta', 'aleppo', 'wikipedia', 'eugh', 'maidan', 'nafta', 'nato', 'uno', 'krankenkasse', 'vg-wort', 'guantanamo', 'fukushima', 'bitcoin', 'lammert'):
-        if w in title:
-            value += 21
-    for w in ('türkei', 'putin', 'hochschule', 'urteil', 'verdi', 'apple', 'google', 'microsoft', 'ibm', 'iwf', 'ezb', 'griechenland', 'volksbegehren', 'brexit', 'airbus', 'pentagon', 'energiewende', 'windkraft', 'lindner', 'paragraf', 'ditib', 'nobelpreis', 'armutsgrenze', 'bundesbank', 'betriebsrat', 'sparkurs', 'bundesrat', 'shinzō', 'libyen', 'mogherini', 'indexfond', 'orbán', 'panama-papers', 'juncker', 'netanyahu', 'deutsche bank', 'cyber-sicherheit', 'yellen', 'windenergie', 'maizière'):
-        if w in title:
-            value += 15
-    for w in ('nsu', 'korruption', 'siedlung', 'steinmeier', 'überwachung', 'fracking', 'android', 'bundesverwaltungsgericht', 'bundesnetzagentur', 'nationalpark', 'syri', 'winterkorn', 'piëch', 'afghan', 'erdoğan', 'böhmermann', 'wissenschaft', 'endlager', 'palästin', 'nahost', 'tsipras', 'rente', 'unternehmenssteuer', 'wilders', 'krankenversicherung', 'gesetz', 'klimaschutz', 'jong-un', 'trudeau', 'BND', 'drohnen', 'peugeot', 'opel', 'orbán', 'reisepass'):
-        if w in title:
-            value += 9
-    for w in ('afd', 'usa', 'trump', 'minister', 'bundestag', 'wahl', 'e-sport', 'gentechnik', 'merkel', 'amazon', 'ebay', 'paypal', 'altmaier', 'schäuble', 'grexit', 'ukraine', 'agrar', 'portugal', 'sanktionen', 'samsung', 'gysi', 'lagarde', 'vorratsspeicherung', 'norovirus', 'unilever', 'patientenakte', 'bannon', 'telefónica', 'sudan', 'unicef', 'fintech', 'salafis', 'sufis', 'exportüberschuss', 'telekom', 'passwort', 'bertelsmann', 'kindergeld', 'martin schulz'):
-        if w in title:
-            value += 7
-    for w in ('ddos', 'berlin', 'china', 'bundespolizei', 'russland', 'japan', 'lebensversicherung', 'präsident', 'facebook', 'anschlag', 'europa', 'deutsch', 'immobilie', 'whatsapp', 'google', 'mcmaster', 'leistungsschutzrecht', 'bafin', 'le pen'):
-        if w in title:
-            value += 2
-    for w in ('experte', 'deepmind', 'gauland', 'bundeswehr', 'delfin', 'foto', 'generation', 'vorwürfe', 'unmut', 'übersicht', 'paukenschlag', 'dax', 'mord', 'hollywood', 'kampf', 'oscar', 'homöopath'):
-        if w in title:
-            value -= 1
-    for w in ('film', 'wunder', 'unisex', 'tweet', 'top ten', 'fantasi', 'sexuell', 'vögel', 'fußball', 'dfb', 'wahrheit', 'manager', 'salat', 'voodoo', 'berlinale', 'portal', 'theater', 'schmutzig', 'killer', 'kolumne', '?', 'skandal', 'cowboy', 'essay', 'kritik', 'münchen', 'selfie', 'mode', 'terror', 'emotion', 'viral', 'nachruf', 'sonneborn', 'seehofer', 'kokain', 'marx', 'junkie', 'ikone', 'egoismus', 'karikatur', 'promi', 'schock', 'kreissäge', 'valentinstag', 'nackt', 'könnte', 'bizarr', 'spiel', 'stur', 'gefährlich', 'hinweise', 'meinung', 'goethe', 'schiller', 'karneval', 'fasnacht', 'fastnacht', 'fasching', 'pizza', 'hölle', 'damokles', 'teambuilding', 'doping', 'knigge'):
-        if w in title:
-            value -= 8
-    for w in ('kunst', 'mies', 'bayern', 'horror', 'brutal', 'compact', 'protz', 'social', 'wollmilch', 'olympia', 'kommentar', '+++', 'schicksal', 'billig', 'troll', 'hashtag', 'betrunken', 'lügendetektor', 'thriller', 'mutig', 'spektakulär', 'krass', 'checkliste', '!', 'zombie', 'willkommen', 'elfmeter', 'spiegel tv', 'video', 'sex', 'ficken', 'saufen', 'schonungslos', 'trumpismus', 'crazy', 'kamikaze', 'buchtipp', 'verkackt', 'playboy', 'gastbeitrag', 'shitstorm', 'wäre', 'abgemagert', 'einhorn'):
-        if w in title:
-            value -= 19
+    for (score_group, words) in boost_it('keyword'):
+        for w in words:
+            if w in title:
+                value += score_group
+
     if len(title) < 15:
         value -= 23
     if len(title) < 30:
         value -= 10
     if len(title) < 40:
         value -= 4
+
     # Value sources
-    source = item[2]
-    for w in ('NP', 'Correctiv'):
-        if w in source:
-            value += 3
-    for w in ('ZEIT', 'NZZ', 'HB', 'FAZ', 'SZ'):
-        if w in source:
-            value += 2
-    for w in ('SpOn', 'Konj'):
-        if w in source:
-            value += 1
-    for w in ('Taz', 'Compact'):
-        if w in source:
-            value -= 1
-    for w in ('RT',):
-        if w in source:
-            value -= 2
+    source = item[2].lower()
+    for source_key in conf['feeds']:
+        if source_key in source:
+            value += conf['feeds'][source_key].get('weight', 0)
+
+    # Source boosts
+    url = item[0].lower()
+    for (score_group, words) in boost_it('sources'):
+        for w in words:
+            if w in url:
+                value += score_group
+
     # Value tags
     tags = item[4].lower()
-    for w in ('mode', 'video', 'bundesliga'):
-        if w in tags:
-            value -= 27
+    for (score_group, words) in boost_it('tags'):
+        for w in words:
+            if w in tags:
+                value += score_group
     return value
 
 def get_All():
     all = list()
-    all.extend(get_default('ZEIT', 'http://newsfeed.zeit.de/index'))
-    all.extend(get_default('SpOn', 'http://www.spiegel.de/index.rss'))
-    all.extend(get_default('FAZ', 'http://www.faz.net/rss/aktuell/'))
-    all.extend(get_default('SZ', 'http://rss.sueddeutsche.de/rss/Topthemen'))
-    all.extend(get_default('Heise', 'https://www.heise.de/newsticker/heise-top-atom.xml'))
-    all.extend(get_default('Taz', 'https://www.taz.de/!p4608;rss/'))
-    all.extend(get_default('Focus', 'http://rss.focus.de/'))
-    all.extend(get_default('RT', 'https://deutsch.rt.com/feeds/news/'))
-    all.extend(get_default('TP', 'https://www.heise.de/tp/news-atom.xml'))
-    all.extend(get_default('HB', 'http://www.handelsblatt.com/contentexport/feed/top-themen/'))
-    all.extend(get_default('Compact', 'https://www.compact-online.de/feed/'))
-    all.extend(get_default('Correctiv', 'https://correctiv.org/artikel/feeds/'))
-    all.extend(get_default('NP', 'https://netzpolitik.org/feed/'))
-    all.extend(get_default('WU', 'http://www.wahlumfrage.de/feed/'))
-    all.extend(get_default('Carta', 'https://feeds2.feedburner.com/carta-homepage-rss'))
-    all.extend(get_default('BG', 'https://feeds.feedburner.com/BerlinerGazette'))
-    all.extend(get_default('Konj', 'https://www.konjunktion.info/feed/'))
-    all.extend(get_default('NZZ', 'https://www.nzz.ch/international.rss'))
-    all.extend(get_default('Freitag', 'https://www.freitag.de/politik/@@RSS'))
-    all.extend(get_default('Cicero', 'http://cicero.de/rss.xml'))
-    all.extend(get_default('WiWo', 'http://www.wiwo.de/contentexport/feed/rss/schlagzeilen'))
-    all.extend(get_default('NDS', 'http://www.nachdenkseiten.de/?feed=atom'))
-    #all.extend(get_default('DF', 'http://www.deutschlandfunk.de/die-nachrichten.353.de.rss'))
-    #all.extend(get_default('ParsToday', 'http://parstoday.com/de/rss'))
+    for source_key in conf['feeds']:
+        all.extend(get_default(source_key, conf['feeds'][source_key]['url']))
+
     rng = Random(42)
     rng.shuffle(all)
     def mycmp(a, b):
@@ -147,22 +114,22 @@ def get_All():
 
 def generate(fh):
     fh.write("""
-    <!DOCTYPE html>
-    <html><head><title>TextNews {NOW}</title>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <meta http-equiv="refresh" content="2000">
-    <style>
-    html, body {{ font-family: sans-serif; font-size: 99%; }}
-    a.meta {{ color: inherit; }}
-    h1 {{ font-weight:normal; }}
-    p.fresh time {{ background-color: #d74; color: #ffc; padding: 0 2px; }}
-    p.yesterday a:link {{ color: #333; }}
-    .value {{ color: #ccc; }}
-    </style>
-    </head><body>
-    <h1 style="font-size:80%">Text<b>News</b> {NOW}</h1>
-    """.format(NOW=NOW.isoformat().replace("T", " ")[:-10]))
+<!DOCTYPE html>
+<html><head><title>TextNews {NOW}</title>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta http-equiv="refresh" content="2000">
+<style>
+html, body {{ font-family: sans-serif; font-size: 99%; }}
+a.meta {{ color: inherit; }}
+h1 {{ font-weight:normal; }}
+p.fresh time {{ background-color: #d74; color: #ffc; padding: 0 2px; }}
+p.yesterday a:link {{ color: #333; }}
+.value {{ color: #ccc; }}
+</style>
+</head><body>
+<h1 style="font-size:80%">Text<b>News</b> {NOW}</h1>
+    """.format(NOW=NOW.isoformat()))
 
     for link, title, src, dt, tags, value in get_All():
         css_classes = list()
@@ -185,5 +152,4 @@ def generate(fh):
     fh.write('<p>Deutsche Nachrichten als reiner Text. <a href="https://github.com/qznc/textnews">Code auf GitHub</a>.</p>')
     fh.write("</body></html>")
 
-with open(TGT, "w") as fh:
-    generate(fh)
+generate(sys.stdout)

--- a/generate.py
+++ b/generate.py
@@ -10,8 +10,9 @@ from random import Random
 import feedparser
 
 DATA = sys.argv[1]
+OUT = sys.argv[1]
 NOW = datetime.datetime.now()
-with open(DATA, 'r') as handle:
+with open(DATA, 'r', encoding='utf-8') as handle:
     conf = yaml.load(handle)
 
 
@@ -152,4 +153,5 @@ p.yesterday a:link {{ color: #333; }}
     fh.write('<p>Deutsche Nachrichten als reiner Text. <a href="https://github.com/qznc/textnews">Code auf GitHub</a>.</p>')
     fh.write("</body></html>")
 
-generate(sys.stdout)
+with open(OUT, 'w', encoding='utf-8') as handle:
+    generate(handle)

--- a/generate.py
+++ b/generate.py
@@ -10,7 +10,7 @@ from random import Random
 import feedparser
 
 DATA = sys.argv[1]
-OUT = sys.argv[1]
+OUT = sys.argv[2]
 NOW = datetime.datetime.now()
 with open(DATA, 'r', encoding='utf-8') as handle:
     conf = yaml.load(handle)

--- a/tech-news.yml
+++ b/tech-news.yml
@@ -1,0 +1,28 @@
+feeds:
+    lobsters:
+        url: https://lobste.rs/rss
+        weight: 3
+    HN:
+        url: https://news.ycombinator.com/rss
+        weight: -1
+weights:
+    keyword:
+        5: |
+            kernel exploit rasperry pi
+        -5: |
+            tag\sproposal doubly-linked rust javascript
+        -21: |
+            has\sdied google\scloud aws lambda square yik yak social app
+            uber lyft apple app\sstore ceo ycombinator ruby
+    tags:
+        10: |
+            hardware
+    sources:
+        15: |
+            phys.org npr.org
+        5: |
+            arxiv.org arstechnica.com
+        -5: |
+            bloomberg.com
+        -21: |
+            youtube.com ycombinator.com


### PR DESCRIPTION
Saw you post this on lobste.rs and it's exactly what I've always wanted but never found the motivation to write. Given that I'm studying german it's doubly useful to me. 

There are some keywords I'd really like to mute on the two big tech sites, so I figured I'd contribute back a refactor of the URLs and keyword boosts as a yaml file. This seems like a personal side project you built to save yourself some time, so you may not want this, but I figured it wouldn't hurt to offer. Cheers for making this available :) Feel free to close if this is not desired.

Forgot: I used the hardcoded string "\s" with " " to allow multi-keyword words in the list and have it be a bit easier to skim visually. It is .. suboptimal but it works.